### PR TITLE
12 remove reflection and add wtf verbose level

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -28,4 +28,7 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
+  <component name="ProjectType">
+    <option name="id" value="Android" />
+  </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     implementation 'com.android.support:support-v4:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/example/src/main/java/com/jeefo/android/logger/BlankFragment.java
+++ b/example/src/main/java/com/jeefo/android/logger/BlankFragment.java
@@ -58,7 +58,7 @@ public class BlankFragment extends Fragment {
                 @Override
                 public void onCrashAndBurn() {
                     try {
-                        @SuppressWarnings("NumericOverflow")
+                        @SuppressWarnings({"NumericOverflow", "unused"})
                         int z = 10 / 0;
                     } catch (Exception exception) {
                         logger.Error(exception, "Did I mention you can log exceptions as well? Placeholders still work also: %s", "argument");

--- a/example/src/main/java/com/jeefo/android/logger/MainActivity.java
+++ b/example/src/main/java/com/jeefo/android/logger/MainActivity.java
@@ -49,22 +49,25 @@ public class MainActivity extends AppCompatActivity {
 
         logger.Info("This message is logged before initializing persistence so it will not appear in the log file");
 
+
         // Setup the persistence for the logger
         // NOTE: Keep in mind that the log files are not stored securely and they can be easily
         //          accessed using a file manager software. Secured storage is planned for one
         //          of the future releases. Until then, you might want to keep persistence only
         //          for in-house testing and turn it off in the release (by removing the following
         //          line only - nothing else will be affected by it)
-        JeefoLogger.initPersistence(this);
-
-        // To fetch the log files at any point, use the following. This method currently works only after JeefoLogger.initPersistence() but this will change in a future version
-        // JeefoLogger.getAllLogFiles(); // THIS RETURNES AN ARRAY WITH THE LOG FILES ON THE DEVICE
-
+        //
         // Setup the lazy logger
         // NOTE: I would always add this line as it can never do harm. Without it, the lazy logger
-        // will throw when logging a message. If you check the implementation of that method, you
+        // will not work as expected. If you check the implementation of that method, you
         // will see that it's doing nothing more than identifying the base package of the module
-        JeefoLogger.initLazyLogger(this);
+        new JeefoLogger.Builder(this)
+                .withPersistence(true)
+                .withLazyLogger(true)
+                .buildAndInit();
+
+        // To fetch the log files at any point, use the following. This method currently works only after buildAndInit() but this will change in a future version
+        // JeefoLogger.getAllLogFiles(); // THIS RETURNES AN ARRAY WITH THE LOG FILES ON THE DEVICE
 
         logger.Debug("Persistence was initialized so from now on, all the log messages will be stored in the file as well");
         logger.Info("The name of today's log file is: %s_Log.txt", simpleDateFormat.format(new Date()));

--- a/jeefologger/build.gradle
+++ b/jeefologger/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-def logLibraryVersion = "1.0.1"
-def logLibraryVersionCode = 4
+def logLibraryVersion = "1.1.0"
+def logLibraryVersionCode = 5
 
 android {
     compileSdkVersion 27

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/AbstractScopedLogger.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/AbstractScopedLogger.java
@@ -18,22 +18,22 @@ package com.jeefo.android.jeefologger;
 
 import android.support.annotation.Nullable;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedList;
 import java.util.Locale;
 
 /**
  * Created by Alexandru Iustin Dochioiu on 5/27/2018
  */
-abstract class AbstractScopedLogger implements ILog {
+abstract class AbstractScopedLogger implements ILog, IInternalLog {
     final static String TAG_KEY_INSTANCE = "Instance";
     final static String TAG_KEY_CLASS = "Class";
     final static String TAG_KEY_METHOD = "Method";
 
+    // Used by classes extending this one
     LinkedList<StackTraceElement> traceElements = null;
 
     private String loggingPrefix = "";
-    protected ILog logger;
+    protected IInternalLog logger;
 
     final String getLoggingPrefix() {
         return loggingPrefix;
@@ -50,6 +50,7 @@ abstract class AbstractScopedLogger implements ILog {
      * @param key                     the {@link String} matching the KEY field
      * @param value                   the {@link String} matching the VALUE field
      * @param throwOnNullOrEmptyValue boolean indicating whether a null value param is acceptable
+     * @throws IllegalArgumentException for null <i>value</i> IF <i>throwOnNullOrEmptyValue</i> is true
      */
     final synchronized void addTag(String key, String value, boolean throwOnNullOrEmptyValue) {
         if (value == null || value.equals("")) {
@@ -64,173 +65,82 @@ abstract class AbstractScopedLogger implements ILog {
     }
 
     /**
-     * Used for initiating the {@link ILog} member using the passed param if not null; otherwise
+     * Used for initiating the {@link IInternalLog} member using the passed param if not null; otherwise
      * a new {@link JeefoLogger} is created
      *
-     * @param logger the {@link ILog} to be stored or null to create a new instance of {@link JeefoLogger}
+     * @param logger the {@link IInternalLog} to be stored or null to create a new instance of {@link JeefoLogger}
      */
-    final synchronized void initLogger(@Nullable ILog logger) {
+    final synchronized void initLogger(@Nullable IInternalLog logger) {
         if (logger == null) {
-            this.logger = new JeefoLogger();
+            this.logger = FinalLogger.getInstance();
         } else {
             this.logger = logger;
         }
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void DebugReflection(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalVerbose(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
         this.traceElements = traceElements;
-
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("DebugReflection",
-                    LinkedList.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Debug(getMessageLogPrefix() + messageToLog, args);
-        }
+        logger.InternalVerbose(traceElements, getMessageLogPrefix() + messageToLog, args);
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param exception     the exception to be logged
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void DebugReflection(final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalVerbose(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
         this.traceElements = traceElements;
-
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("DebugReflection",
-                    LinkedList.class, Exception.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, exception, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Debug(exception, getMessageLogPrefix() + messageToLog, args);
-        }
+        logger.InternalVerbose(traceElements, exception, getMessageLogPrefix() + messageToLog, args);
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void InfoReflection(final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalDebug(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
         this.traceElements = traceElements;
-
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("InfoReflection",
-                    LinkedList.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Info(getMessageLogPrefix() + messageToLog, args);
-        }
+        logger.InternalDebug(traceElements, getMessageLogPrefix() + messageToLog, args);
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void WarnReflection(final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalDebug(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
         this.traceElements = traceElements;
-
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("WarnReflection",
-                    LinkedList.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Warn(getMessageLogPrefix() + messageToLog, args);
-        }
+        logger.InternalDebug(traceElements, exception, getMessageLogPrefix() + messageToLog, args);
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param exception     the exception to be logged
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void WarnReflection(final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalInfo(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
         this.traceElements = traceElements;
-
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("WarnReflection",
-                    LinkedList.class, Exception.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, exception, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Warn(exception, getMessageLogPrefix() + messageToLog, args);
-        }
+        logger.InternalInfo(traceElements, getMessageLogPrefix() + messageToLog, args);
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void ErrorReflection(final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalWarn(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
         this.traceElements = traceElements;
-
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("ErrorReflection",
-                    LinkedList.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Error(getMessageLogPrefix() + messageToLog, args);
-        }
+        logger.InternalWarn(traceElements, getMessageLogPrefix() + messageToLog, args);
     }
 
-    /**
-     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
-     *                      computing the logging prefix
-     * @param exception     the exception to be logged
-     * @param messageToLog  the message to be logged
-     * @param args          arguments for messageToLog
-     */
-    synchronized void ErrorReflection(final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+    @Override
+    public final synchronized void InternalWarn(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
         this.traceElements = traceElements;
+        logger.InternalWarn(traceElements, exception, getMessageLogPrefix() + messageToLog, args);
+    }
 
-        try {
-            logger.getClass().getSuperclass().getDeclaredMethod("ErrorReflection",
-                    LinkedList.class, Exception.class, String.class, Object[].class)
-                    .invoke(logger, this.traceElements, exception, getMessageLogPrefix() + messageToLog, args);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        } catch (NoSuchMethodException e) {
-            logger.Error(exception, getMessageLogPrefix() + messageToLog, args);
-        }
+    @Override
+    public final synchronized void InternalError(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        this.traceElements = traceElements;
+        logger.InternalError(traceElements, getMessageLogPrefix() + messageToLog, args);
+    }
+
+    @Override
+    public final synchronized void InternalError(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        this.traceElements = traceElements;
+        logger.InternalError(traceElements, exception, getMessageLogPrefix() + messageToLog, args);
+    }
+
+    @Override
+    public final synchronized void InternalWtf(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        this.traceElements = traceElements;
+        logger.InternalWtf(traceElements, getMessageLogPrefix() + messageToLog, args);
+    }
+
+    @Override
+    public final synchronized void InternalWtf(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        this.traceElements = traceElements;
+        logger.InternalWtf(traceElements, exception, getMessageLogPrefix() + messageToLog, args);
     }
 }

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/FinalLogger.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/FinalLogger.java
@@ -1,0 +1,138 @@
+package com.jeefo.android.jeefologger;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import java.util.LinkedList;
+
+import static com.jeefo.android.jeefologger.StringUtils.getFormattedMessage;
+
+/**
+ * Created by Alexandru Iustin Dochioiu on 7/15/2018
+ */
+@SuppressWarnings("WeakerAccess")
+public class FinalLogger implements IInternalLog {
+    static final String TAG_LOGGING_PREFIX = "[JeeFo-Log]";
+    @LogLevel
+    static int persistenceMinLevel = LogLevel.VERBOSE;
+
+    private static final ILog persistentLogger = PersistentLogger.getInstance();
+
+    private static FinalLogger instance;
+
+    /**
+     * Internal method used for getting the same instance always
+     *
+     * @return instance of {@link FinalLogger}
+     */
+    @NonNull
+    static synchronized FinalLogger getInstance() {
+        if (instance == null) {
+            instance = new FinalLogger();
+        }
+        return instance;
+    }
+
+    private FinalLogger() {
+    }
+
+    @Override
+    public void InternalVerbose(@Nullable LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(null, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.VERBOSE) {
+            Log.v(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Verbose(finalMessage);
+    }
+
+    @Override
+    public void InternalVerbose(@Nullable LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(exception, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.VERBOSE) {
+            Log.v(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Verbose(finalMessage);
+    }
+
+    @Override
+    public void InternalDebug(@Nullable LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(null, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.DEBUG) {
+            Log.d(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Debug(finalMessage);
+    }
+
+    @Override
+    public void InternalDebug(@Nullable LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(exception, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.DEBUG) {
+            Log.d(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Debug(finalMessage);
+    }
+
+    @Override
+    public void InternalInfo(@Nullable LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(null, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.INFO) {
+            Log.i(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Info(finalMessage);
+    }
+
+    @Override
+    public void InternalWarn(@Nullable LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(null, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.WARN) {
+            Log.w(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Warn(finalMessage);
+    }
+
+    @Override
+    public void InternalWarn(@Nullable LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(exception, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.WARN) {
+            Log.w(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Warn(finalMessage);
+    }
+
+    @Override
+    public void InternalError(@Nullable LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(null, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.ERROR) {
+            Log.e(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Error(finalMessage);
+    }
+
+    @Override
+    public void InternalError(@Nullable LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(exception, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.ERROR) {
+            Log.e(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Error(finalMessage);
+    }
+
+    @Override
+    public void InternalWtf(@Nullable LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(null, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.WTF) {
+            Log.wtf(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Wtf(finalMessage);
+    }
+
+    @Override
+    public void InternalWtf(@Nullable LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args) {
+        String finalMessage = getFormattedMessage(exception, messageToLog, args);
+        if (persistenceMinLevel <= LogLevel.WTF) {
+            Log.wtf(TAG_LOGGING_PREFIX + PersistentTagsManager.getTagsStringPrefix(), finalMessage);
+        }
+        persistentLogger.Wtf(finalMessage);
+    }
+}

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/IInternalLog.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/IInternalLog.java
@@ -1,0 +1,127 @@
+package com.jeefo.android.jeefologger;
+
+import android.support.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+
+/**
+ * Created by Alexandru Iustin Dochioiu on 7/14/2018
+ */
+interface IInternalLog extends Serializable {
+
+    /**
+     * Write a custom message to the verbose log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalVerbose(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args);
+
+    /**
+     * Write the exception message to the verbose log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param exception     the exception to be logged
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalVerbose(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args);
+
+    /**
+     * Write a custom message to the debug log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalDebug(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args);
+
+    /**
+     * Write the exception message to the debug log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param exception     the exception to be logged
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalDebug(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args);
+
+    /**
+     * Write a custom message to the info log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalInfo(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args);
+
+    /**
+     * Write a custom message to the warning logged
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalWarn(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args);
+
+    /**
+     * Write the exception message to the warning log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param exception     the exception to be logged
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalWarn(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args);
+
+    /**
+     * Write a custom message to the error log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalError(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args);
+
+    /**
+     * Write the exception message and a custom message to the error log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param exception     the exception to be logged
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalError(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args);
+
+    /**
+     * Write a custom message to the wtf log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalWtf(@Nullable final LinkedList<StackTraceElement> traceElements, String messageToLog, Object... args);
+
+    /**
+     * Write the exception message and a custom message to the wtf log
+     *
+     * @param traceElements the stackTrace (can be null) used by the {@link SmartLogger} when
+     *                      computing the logging prefix
+     * @param exception     the exception to be logged
+     * @param messageToLog  the message to be logged
+     * @param args          arguments for messageToLog
+     */
+    void InternalWtf(@Nullable final LinkedList<StackTraceElement> traceElements, Exception exception, String messageToLog, Object... args);
+}

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/ILog.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/ILog.java
@@ -20,67 +20,116 @@ import java.io.Serializable;
 
 /**
  * Created by Alexandru Iustin Dochioiu on 13/12/17.
- *
+ * <p>
  * Interface used for logging messages. It is {@link Serializable} so we can pass it through
  * Bundles
  */
 public interface ILog extends Serializable {
 
     /**
-     * Write a custom message to the debug log
+     * Write a custom message to the verbose log
+     *
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
+     */
+    void Verbose(String messageToLog, Object... args);
+
+    /**
+     * Write the exception message to the verbose log
+     *
+     * @param exception    the exception to be logged
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    void Verbose(Exception exception, String messageToLog, Object... args);
+
+    /**
+     * Write a custom message to the debug log
+     *
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
      */
     void Debug(String messageToLog, Object... args);
 
     /**
      * Write the exception message to the debug log
-     * @param exception the exception to be logged
+     *
+     * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
      */
     void Debug(Exception exception, String messageToLog, Object... args);
 
     /**
      * Write a custom message to the info log
+     *
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
      */
     void Info(String messageToLog, Object... args);
 
     /**
      * Write a custom message to the warning logged
+     *
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
      */
     void Warn(String messageToLog, Object... args);
 
     /**
      * Write the exception message to the warning log
-     * @param exception the exception to be logged
+     *
+     * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
      */
     void Warn(Exception exception, String messageToLog, Object... args);
 
     /**
      * Write a custom message to the error log
+     *
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
      */
     void Error(String messageToLog, Object... args);
 
     /**
      * Write the exception message and a custom message to the error log
-     * @param exception the exception to be logged
+     *
+     * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
-     * @param args arguments for messageToLog
+     * @param args         arguments for messageToLog
      */
     void Error(Exception exception, String messageToLog, Object... args);
 
     /**
      * Write the exception message to the error log
+     *
      * @param exception the exception to be logged
      */
     void Error(Exception exception);
+
+    /**
+     * Write a custom message to the wtf log
+     *
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    void Wtf(String messageToLog, Object... args);
+
+    /**
+     * Write the exception message and a custom message to the wtf log
+     *
+     * @param exception    the exception to be logged
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    void Wtf(Exception exception, String messageToLog, Object... args);
+
+    /**
+     * Write the exception message to the wtf log
+     *
+     * @param exception the exception to be logged
+     */
+    void Wtf(Exception exception);
 }

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/JeefoLogger.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/JeefoLogger.java
@@ -29,7 +29,7 @@ import java.lang.ref.WeakReference;
  */
 @SuppressWarnings({"WeakerAccess", "UnusedReturnValue", "unused"})
 public class JeefoLogger {
-    static final String TAG_LIBRARY_LOG = "[LIBRARY-ERROR-JEEFO]";
+    static final String TAG_LIBRARY_LOG = "[LIB-JEEFO]";
 
     /**
      * Public method used for initializing persistence. If persistence is not desired, do not

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/LazyLogger.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/LazyLogger.java
@@ -17,88 +17,189 @@
 
 package com.jeefo.android.jeefologger;
 
+import android.util.Log;
+
 /**
  * Created by Alexandru Iustin Dochioiu on 6/9/2018
- *
+ * <p>
  * Static class used for accessing the power of the {@link LazyLoggerInternal}
  * NOTE: In order to use those static methods, you NEED to initialize the lazy logger beforehand
- *  --JeefoLogger.initLazyLogger(Context)--
+ * --JeefoLogger.initLazyLogger(Context)--
  */
 public class LazyLogger {
     private static final ILog lazyLoggerImplementation = new LazyLoggerInternal();
+    static String packageName = null;
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
+     */
+    public static void Verbose(String messageToLog, Object... args) {
+        try {
+            lazyLoggerImplementation.Verbose(messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.v(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(null, messageToLog, args));
+        }
+    }
+
+    /**
+     * @param exception    the exception to be logged
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    public static void Verbose(Exception exception, String messageToLog, Object... args) {
+        try {
+            lazyLoggerImplementation.Verbose(exception, messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.v(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, messageToLog, args));
+        }
+    }
+
+    /**
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
      */
     public static void Debug(String messageToLog, Object... args) {
-        lazyLoggerImplementation.Debug(messageToLog, args);
+        try {
+            lazyLoggerImplementation.Debug(messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.d(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(null, messageToLog, args));
+        }
     }
 
     /**
      * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Debug(Exception exception, String messageToLog, Object... args) {
-        lazyLoggerImplementation.Debug(exception, messageToLog, args);
+        try {
+            lazyLoggerImplementation.Debug(exception, messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.d(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, messageToLog, args));
+        }
     }
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Info(String messageToLog, Object... args) {
-        lazyLoggerImplementation.Info(messageToLog, args);
+        try {
+            lazyLoggerImplementation.Info(messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.i(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(null, messageToLog, args));
+        }
     }
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Warn(String messageToLog, Object... args) {
-        lazyLoggerImplementation.Warn(messageToLog, args);
+        try {
+            lazyLoggerImplementation.Warn(messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.w(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(null, messageToLog, args));
+        }
     }
 
     /**
      * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Warn(Exception exception, String messageToLog, Object... args) {
-        lazyLoggerImplementation.Warn(exception, messageToLog, args);
+        try {
+            lazyLoggerImplementation.Warn(exception, messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.w(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, messageToLog, args));
+        }
     }
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Error(String messageToLog, Object... args) {
-        lazyLoggerImplementation.Error(messageToLog, args);
+        try {
+            lazyLoggerImplementation.Error(messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.e(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(null, messageToLog, args));
+        }
     }
 
     /**
      * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Error(Exception exception, String messageToLog, Object... args) {
-        lazyLoggerImplementation.Error(exception, messageToLog, args);
+        try {
+            lazyLoggerImplementation.Error(exception, messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.e(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, messageToLog, args));
+        }
     }
 
     /**
      * @param exception the exception to be logged
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     public static void Error(Exception exception) {
-        lazyLoggerImplementation.Error(exception);
+        try {
+            lazyLoggerImplementation.Error(exception);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.e(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, ""));
+        }
+    }
+
+    /**
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    public static void Wtf(String messageToLog, Object... args) {
+        try {
+            lazyLoggerImplementation.Wtf(messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.wtf(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(null, messageToLog, args));
+        }
+    }
+
+    /**
+     * @param exception    the exception to be logged
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    public static void Wtf(Exception exception, String messageToLog, Object... args) {
+        try {
+            lazyLoggerImplementation.Wtf(exception, messageToLog, args);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.wtf(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, messageToLog, args));
+        }
+    }
+
+    /**
+     * @param exception the exception to be logged
+     */
+    public static void Wtf(Exception exception) {
+        try {
+            lazyLoggerImplementation.Wtf(exception);
+        } catch (Exception libraryException) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, StringUtils.getFormattedMessage(libraryException, "LazyLogger"));
+            Log.wtf(FinalLogger.TAG_LOGGING_PREFIX, StringUtils.getFormattedMessage(exception, ""));
+        }
     }
 
     /**

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/LazyLoggerInternal.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/LazyLoggerInternal.java
@@ -35,17 +35,16 @@ class LazyLoggerInternal extends AbstractScopedLogger {
     }
 
     /**
-     * @return the prefix containing the tags
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
+     * @return the prefix containing the tags or a LazyLoggerNotInitialized tag if that's the case
      */
     @Override
     String getMessageLogPrefix() {
-        if (JeefoLogger.packageName == null) {
-            throw new ExceptionInInitializerError("JeefoLogger.initLazyLogger(Context) should have been called before logging a message with this logger");
+        if (LazyLogger.packageName == null) {
+            return "[LazyLoggerNotInitialized]";
         }
         StringBuilder logPrefix = new StringBuilder();
 
-        List<Pair<String, LinkedList<String>>> traces = LazyLoggerUtils.getAllTraceForPackage(JeefoLogger.packageName);
+        List<Pair<String, LinkedList<String>>> traces = LazyLoggerUtils.getAllTraceForPackage(LazyLogger.packageName);
 
         for (Pair<String, LinkedList<String>> trace : traces) {
             logPrefix.append("[").append(TAG_KEY_CLASS).append(" ").append(trace.first).append("]");
@@ -60,82 +59,121 @@ class LazyLoggerInternal extends AbstractScopedLogger {
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
+     */
+    @Override
+    public void Verbose(String messageToLog, Object... args) {
+        InternalVerbose((LinkedList) null, messageToLog, args);
+    }
+
+    /**
+     * @param exception    the exception to be logged
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    @Override
+    public void Verbose(Exception exception, String messageToLog, Object... args) {
+        InternalVerbose((LinkedList) null, exception, messageToLog, args);
+    }
+
+    /**
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
      */
     @Override
     public void Debug(String messageToLog, Object... args) {
-        DebugReflection((LinkedList) null, messageToLog, args);
+        InternalDebug((LinkedList) null, messageToLog, args);
     }
 
     /**
      * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Debug(Exception exception, String messageToLog, Object... args) {
-        DebugReflection((LinkedList) null, exception, messageToLog, args);
+        InternalDebug((LinkedList) null, exception, messageToLog, args);
     }
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Info(String messageToLog, Object... args) {
-        InfoReflection((LinkedList) null, messageToLog, args);
+        InternalInfo((LinkedList) null, messageToLog, args);
     }
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Warn(String messageToLog, Object... args) {
-        WarnReflection((LinkedList) null, messageToLog, args);
+        InternalWarn((LinkedList) null, messageToLog, args);
     }
 
     /**
      * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Warn(Exception exception, String messageToLog, Object... args) {
-        WarnReflection((LinkedList) null, exception, messageToLog, args);
+        InternalWarn((LinkedList) null, exception, messageToLog, args);
     }
 
     /**
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Error(String messageToLog, Object... args) {
-        ErrorReflection((LinkedList) null, messageToLog, args);
+        InternalError((LinkedList) null, messageToLog, args);
     }
 
     /**
      * @param exception    the exception to be logged
      * @param messageToLog the message to be logged
      * @param args         arguments for messageToLog
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Error(Exception exception, String messageToLog, Object... args) {
-        ErrorReflection((LinkedList) null, exception, messageToLog, args);
+        InternalError((LinkedList) null, exception, messageToLog, args);
     }
 
     /**
      * @param exception the exception to be logged
-     * @throws ExceptionInInitializerError if this method is called before JeefoLogger.initLazyLogger(Context)
      */
     @Override
     public void Error(Exception exception) {
-        ErrorReflection((LinkedList) null, exception, "");
+        InternalError((LinkedList) null, exception, "");
+    }
+
+    /**
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    @Override
+    public void Wtf(String messageToLog, Object... args) {
+        InternalWtf((LinkedList) null, messageToLog, args);
+
+    }
+
+    /**
+     * @param exception    the exception to be logged
+     * @param messageToLog the message to be logged
+     * @param args         arguments for messageToLog
+     */
+    @Override
+    public void Wtf(Exception exception, String messageToLog, Object... args) {
+        InternalWtf((LinkedList) null, exception, messageToLog, args);
+    }
+
+    /**
+     * @param exception the exception to be logged
+     */
+    @Override
+    public void Wtf(Exception exception) {
+        InternalWtf((LinkedList) null, exception, "");
     }
 }

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/LazyLoggerUtils.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/LazyLoggerUtils.java
@@ -49,6 +49,12 @@ public class LazyLoggerUtils {
                 final String className = getClassNameFromFileName(ste[index].getFileName());
                 String methodName = ste[index].getMethodName() + "()";
 
+                if (methodName.contains("access$")) {
+                    // Those are compiler generated methods used for accessing members of a (host)
+                    // class from an anon class. We are not interested in displaying them
+                    continue;
+                }
+
                 if (packageCalls.size() > 0) {
                     if (className.equals(packageCalls.getLast().first)) {
                         if (!isAnonymousClass) {

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/LogLevel.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/LogLevel.java
@@ -1,0 +1,25 @@
+package com.jeefo.android.jeefologger;
+
+import android.support.annotation.IntDef;
+
+import static com.jeefo.android.jeefologger.LogLevel.DEBUG;
+import static com.jeefo.android.jeefologger.LogLevel.ERROR;
+import static com.jeefo.android.jeefologger.LogLevel.INFO;
+import static com.jeefo.android.jeefologger.LogLevel.NONE;
+import static com.jeefo.android.jeefologger.LogLevel.VERBOSE;
+import static com.jeefo.android.jeefologger.LogLevel.WARN;
+import static com.jeefo.android.jeefologger.LogLevel.WTF;
+
+/**
+ * Created by Alexandru Iustin Dochioiu on 7/15/2018
+ */
+@IntDef({VERBOSE, DEBUG, INFO, WARN, ERROR, WTF, NONE})
+public @interface LogLevel {
+    int VERBOSE = 0;
+    int DEBUG = 1;
+    int INFO = 2;
+    int WARN = 3;
+    int ERROR = 4;
+    int WTF = 5;
+    int NONE = 6;
+}

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/PersistentLogger.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/PersistentLogger.java
@@ -28,7 +28,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 
 /**
@@ -36,38 +35,52 @@ import java.util.Locale;
  */
 
 class PersistentLogger implements ILog {
+
+    @LogLevel
+    private static int persistenceMinLevel = LogLevel.NONE;
     private static boolean wasInitialised = false;
     private static File logsPath;
     private static File logFile;
 
     private static final Object lockObject = new Object();
 
+    private static PersistentLogger instance;
+
+    /**
+     * Internal method used for getting the same instance always
+     *
+     * @return instance of {@link PersistentLogger}
+     */
+    @NonNull
+    static synchronized ILog getInstance() {
+        if (instance == null) {
+            instance = new PersistentLogger();
+        }
+
+        return instance;
+    }
+
     /**
      * @param context any kind of context.
      * @throws IllegalArgumentException if the context is null
      */
-    public static void init(@NonNull final Context context) {
+    public static void init(@NonNull final Context context, @LogLevel final int persistenceLevel) {
         // use the same lock as the one for the messages writing to avoid some kind of race
         // condition (a very unlikely one though but still good to have this)
         synchronized (lockObject) {
+            persistenceMinLevel = persistenceLevel;
+
             if (!wasInitialised) {
                 //noinspection ConstantConditions
                 if (context == null) {
                     throw new IllegalArgumentException("Non-null context required.");
                 }
 
-                Context applicationContext;
-                if (context.getApplicationContext() != null) {
-                    applicationContext = context.getApplicationContext();
-                } else {
-                    applicationContext = context;
-                }
-
                 //TODO: Move log files into a private dir
                 if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-                    logsPath = applicationContext.getExternalFilesDir(Environment.DIRECTORY_DCIM);
+                    logsPath = context.getExternalFilesDir(Environment.DIRECTORY_DCIM);
                 } else {
-                    logsPath = applicationContext.getFilesDir();
+                    logsPath = context.getFilesDir();
                 }
 
                 try {
@@ -76,7 +89,7 @@ class PersistentLogger implements ILog {
                         logsPath = newLogsPath;
                     }
                 } catch (Exception e) {
-                    Log.d("JeeFo-Log-Internal", "Failed to create logs directory, use default DCIM instead ; " + e.getMessage());
+                    Log.w(JeefoLogger.TAG_LIBRARY_LOG, "Failed to create logs directory, use default DCIM instead ; " + e.getMessage());
                 }
 
                 final String timeStamp = new SimpleDateFormat("yyyy_MM_dd", Locale.UK).format(new Date());
@@ -92,14 +105,14 @@ class PersistentLogger implements ILog {
                                     "Session Started" + "\n");
                     wasInitialised = true;
                 } catch (Exception e) {
-                    Log.e(JeefoLogger.loggingPrefix, String.format(Locale.UK,
+                    Log.e(JeefoLogger.TAG_LIBRARY_LOG, String.format(Locale.UK,
                             "Failed to open or create the file for the persistent logging: %s", e.getMessage()));
                 } finally {
                     if (outStream != null) {
                         try {
                             outStream.close();
                         } catch (Exception e) {
-                            Log.e(JeefoLogger.loggingPrefix, String.format(Locale.UK,
+                            Log.e(JeefoLogger.TAG_LIBRARY_LOG, String.format(Locale.UK,
                                     "Failed to close the file stream for the persistent logger: %s", e.getMessage()));
                         }
                     }
@@ -110,66 +123,87 @@ class PersistentLogger implements ILog {
 
     /**
      * @return array of all the log files as long as the persistent logging was initialized;
-     *              null if the persistent logging was not initialized
+     * null if the persistent logging was not initialized
      */
     @Nullable
     static File[] getAllLogFiles() {
-        if (wasInitialised) {
-            return logsPath.listFiles();
-        } else {
-            return null;
+        synchronized (lockObject) {
+            if (wasInitialised) {
+                return logsPath.listFiles();
+            } else {
+                return null;
+            }
         }
     }
 
-    /**
-     * Internal Constructor to avoid instantiation outside the library as it should never
-     * be required
-     */
-    PersistentLogger() {};
+    @Override
+    public void Verbose(String messageToLog, Object... args) {
+        logMessageIfInitialized("VERBOSE", LogLevel.VERBOSE, null, messageToLog, args);
+    }
+
+    @Override
+    public void Verbose(Exception exception, String messageToLog, Object... args) {
+        logMessageIfInitialized("VERBOSE", LogLevel.VERBOSE, exception, messageToLog, args);
+    }
 
     @Override
     public void Debug(String messageToLog, Object... args) {
-        logMessage("DEBUG", null, messageToLog, args);
+        logMessageIfInitialized("DEBUG", LogLevel.DEBUG, null, messageToLog, args);
     }
 
     @Override
     public void Debug(Exception exception, String messageToLog, Object... args) {
-        logMessage("DEBUG", exception, messageToLog, args);
+        logMessageIfInitialized("DEBUG", LogLevel.DEBUG, exception, messageToLog, args);
     }
 
     @Override
     public void Info(String messageToLog, Object... args) {
-        logMessage("INFO", null, messageToLog, args);
+        logMessageIfInitialized("INFO", LogLevel.INFO, null, messageToLog, args);
     }
 
     @Override
     public void Warn(String messageToLog, Object... args) {
-        logMessage("WARN", null, messageToLog, args);
+        logMessageIfInitialized("WARN", LogLevel.WARN, null, messageToLog, args);
     }
 
     @Override
     public void Warn(Exception exception, String messageToLog, Object... args) {
-        logMessage("WARN", exception, messageToLog, args);
+        logMessageIfInitialized("WARN", LogLevel.WARN, exception, messageToLog, args);
     }
 
     @Override
     public void Error(String messageToLog, Object... args) {
-        logMessage("ERROR", null, messageToLog, args);
+        logMessageIfInitialized("ERROR", LogLevel.ERROR, null, messageToLog, args);
     }
 
     @Override
     public void Error(Exception exception, String messageToLog, Object... args) {
-        logMessage("ERROR", exception, messageToLog, args);
+        logMessageIfInitialized("ERROR", LogLevel.ERROR, exception, messageToLog, args);
     }
 
     @Override
     public void Error(Exception exception) {
-        logMessage("ERROR", exception);
+        logMessageIfInitialized("ERROR", LogLevel.ERROR, exception);
     }
 
-    private void logMessage(@NonNull String type, @Nullable Exception exception, @NonNull String messageToLog, @Nullable Object... args) {
-        if (wasInitialised) {
-            synchronized (lockObject) {
+    @Override
+    public void Wtf(String messageToLog, Object... args) {
+        logMessageIfInitialized("WTF", LogLevel.WTF, null, messageToLog, args);
+    }
+
+    @Override
+    public void Wtf(Exception exception, String messageToLog, Object... args) {
+        logMessageIfInitialized("WTF", LogLevel.WTF, exception, messageToLog, args);
+    }
+
+    @Override
+    public void Wtf(Exception exception) {
+        logMessageIfInitialized("WTF", LogLevel.WTF, exception);
+    }
+
+    private void logMessageIfInitialized(@NonNull String type, @LogLevel int logLevel, @Nullable Exception exception, @NonNull String messageToLog, @Nullable Object... args) {
+        synchronized (lockObject) {
+            if (wasInitialised && logLevel >= persistenceMinLevel) {
                 try {
                     FileWriter logWriter = new FileWriter(logFile, true);
                     BufferedWriter outStream = new BufferedWriter(logWriter);
@@ -185,9 +219,9 @@ class PersistentLogger implements ILog {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private void logMessage(String type, Exception exception) {
-        if (wasInitialised) {
-            synchronized (lockObject) {
+    private void logMessageIfInitialized(String type, @LogLevel int logLevel, Exception exception) {
+        synchronized (lockObject) {
+            if (wasInitialised && logLevel >= persistenceMinLevel) {
                 try {
                     FileWriter logWriter = new FileWriter(logFile, true);
                     BufferedWriter outStream = new BufferedWriter(logWriter);
@@ -198,6 +232,20 @@ class PersistentLogger implements ILog {
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
+            }
+        }
+    }
+
+    /**
+     * Private to avoid instantiation as this is a singleton
+     */
+    private PersistentLogger() {
+    }
+
+    public static synchronized void setIsActive(boolean usePersistence) {
+        if (!usePersistence) {
+            synchronized (lockObject) {
+                persistenceMinLevel = LogLevel.NONE;
             }
         }
     }

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/PersistentTagsManager.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/PersistentTagsManager.java
@@ -25,6 +25,7 @@ import java.util.List;
 /**
  * Created by Alexandru Iustin Dochioiu on 5/27/2018
  */
+@SuppressWarnings("WeakerAccess")
 final class PersistentTagsManager {
 
     public static final int TAG_ID_IS_NULL = -1;

--- a/jeefologger/src/main/java/com/jeefo/android/jeefologger/SmartLoggerFactory.java
+++ b/jeefologger/src/main/java/com/jeefo/android/jeefologger/SmartLoggerFactory.java
@@ -18,6 +18,7 @@ package com.jeefo.android.jeefologger;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 /**
  * Created by Alexandru Iustin Dochioiu on 6/3/2018
@@ -36,7 +37,7 @@ public class SmartLoggerFactory {
      * @return a new {@link SmartLogger} which will not have an instance tag
      */
     @NonNull
-    public static SmartLogger createSmartLogger() {
+    public static ILog createSmartLogger() {
         return new SmartLogger(false);
     }
 
@@ -57,7 +58,7 @@ public class SmartLoggerFactory {
      * @return a newly created {@link SmartLogger}
      */
     @NonNull
-    public static SmartLogger createSmartLogger(boolean addInstanceTag) {
+    public static ILog createSmartLogger(boolean addInstanceTag) {
         return new SmartLogger(addInstanceTag);
     }
 
@@ -66,15 +67,26 @@ public class SmartLoggerFactory {
      * @return the {@link SmartLogger} extended with new tags (and no instance tag added)
      */
     @NonNull
-    public static SmartLogger createSmartLogger(@Nullable ILog logger) {
-        if (logger instanceof SmartLogger) {
-            if (isSameClass((SmartLogger) logger)) {
-                return (SmartLogger) logger;
+    public static ILog createSmartLogger(@Nullable ILog logger) {
+        if (logger == null) {
+            return new SmartLogger(null, false);
+        }
+
+        final IInternalLog internalLog = (IInternalLog) logger;
+        //noinspection ConstantConditions
+        if (internalLog == null) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, "SmartLoggerFactory: ILog cannot be converted to IInternalLog");
+            return logger;
+        }
+
+        if (internalLog instanceof SmartLogger) {
+            if (isSameClass((SmartLogger) internalLog)) {
+                return logger;
             } else {
-                return new SmartLogger(logger, false);
+                return new SmartLogger(internalLog, false);
             }
         } else {
-            return new SmartLogger(logger, false);
+            return new SmartLogger(internalLog, false);
         }
     }
 
@@ -96,15 +108,26 @@ public class SmartLoggerFactory {
      * @return the {@link SmartLogger} extended with new tags
      */
     @NonNull
-    public static SmartLogger createSmartLogger(@Nullable ILog logger, boolean addInstanceTag) {
-        if (logger instanceof SmartLogger) {
-            if (isSameClass((SmartLogger) logger)) {
-                return (SmartLogger) logger;
+    public static ILog createSmartLogger(@Nullable ILog logger, boolean addInstanceTag) {
+        if (logger == null) {
+            return new SmartLogger(null, addInstanceTag);
+        }
+
+        final IInternalLog internalLog = (IInternalLog) logger;
+        //noinspection ConstantConditions
+        if (internalLog == null) {
+            Log.wtf(JeefoLogger.TAG_LIBRARY_LOG, "SmartLoggerFactory: ILog cannot be converted to IInternalLog");
+            return logger;
+        }
+
+        if (internalLog instanceof SmartLogger) {
+            if (isSameClass((SmartLogger) internalLog)) {
+                return (SmartLogger) internalLog;
             } else {
-                return new SmartLogger(logger, addInstanceTag);
+                return new SmartLogger(internalLog, addInstanceTag);
             }
         } else {
-            return new SmartLogger(logger, addInstanceTag);
+            return new SmartLogger(internalLog, addInstanceTag);
         }
     }
 
@@ -116,7 +139,7 @@ public class SmartLoggerFactory {
      * @return true if the {@link SmartLogger} was created in the same class as the
      *          one which requested a new {@link SmartLogger}; false otherwise
      */
-    private static boolean isSameClass(SmartLogger smartLogger) {
+    private static boolean isSameClass(@NonNull SmartLogger smartLogger) {
         String upperClassName = smartLogger.getFullClientClassName();
         if (upperClassName.contains("$")) {
             upperClassName = upperClassName.substring(0, upperClassName.indexOf("$"));


### PR DESCRIPTION
* Build tools updated to last version
* Constraints layout dependency for example project updated to last version
* Example project now uses builder for initialization
* Increased library version name and code to v1.1.0 (which will be the next release)
* JeeFoLogger now uses builder pattern for initialization
* JeeFoLogger is now used only for initializing library params and some logging was moved to a new class: FinalLogger (which logs to Android Logger and PersistentLogger)
* Previous JeeFoLogger initialization is now deprecated and will be removed in 2019
* Corrected docs about the name of the files (used mm instead of MM for month)
* Added new tag for library messages to be logged in logcat
* Access anon classes are now ignored
* LazyLogger does not throw anymore if used without initialization
* LazyLogger, SmartLogger and ScopedLogger methods are now wrapped in try/catch blocks so they can never throw. The message will not be lost though, it will only not have the tags added and a library error message will be logged instead
* PersistentLogger is now singleton to ensure thread safety
* Minimum level for persistence logging was added (can be set using the jeefologger builder)
* Minimum level for logcat logging was added (can be set using the jeefologger builder)
* SmartLoggerFactory now returns ILog (as it should)